### PR TITLE
Added --since, --trail, and --timestamps to oc logs function

### DIFF
--- a/oc.py
+++ b/oc.py
@@ -68,7 +68,7 @@ def get_pods():
 
 
 def logs(pod, since=None, tail=None, timestamps=None):
-    "Get logs from pod. Provides flags for the `--since`, `--     tail`, and `--timestamps` flags.."
+    "Get logs from pod. Provides flags for the `since`, `tail`, and `timestamps` flags."
     cmd = f'logs {pod}'
     if since:
         cmd = cmd + f' --since={since}'

--- a/oc.py
+++ b/oc.py
@@ -67,9 +67,15 @@ def get_pods():
     return parse(oc(cmd))
 
 
-def logs(pod):
-    "Get logs from pod."
+def logs(pod, since=None, tail=None, timestamps=None):
+    "Get logs from pod. Provides flags for the `--since`, `--     tail`, and `--timestamps` flags.."
     cmd = f'logs {pod}'
+    if since:
+        cmd = cmd + f' --since={since}'
+    if tail:
+        cmd = cmd + f' --tail={tail}'
+    if timestamps:
+        cmd = cmd + f' --timestamps={timestamps}'
     return parse(oc(cmd))
 
 


### PR DESCRIPTION
Added ability to optionally pass the `--since` `--trail`, and `--timestamps` flag options in `oc logs` to the `logs` function.